### PR TITLE
Fix concurrency warnings in HeadlinesViewModel

### DIFF
--- a/ViewModels/HeadlinesViewModel.swift
+++ b/ViewModels/HeadlinesViewModel.swift
@@ -1,6 +1,7 @@
-yesimport SwiftUI
+import SwiftUI
 import Combine
 
+@MainActor
 class HeadlinesViewModel: ObservableObject {
     @Published var articles: [Article] = []
     @Published var isLoading: Bool = false

--- a/eTamil/HeadlinesViewModel.swift
+++ b/eTamil/HeadlinesViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Combine
 
+@MainActor
 class HeadlinesViewModel: ObservableObject {
     @Published var articles: [Article] = []
     @Published var isLoading: Bool = false

--- a/eTamil/ViewModels/HeadlinesViewModel.swift
+++ b/eTamil/ViewModels/HeadlinesViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Combine
 
+@MainActor
 class HeadlinesViewModel: ObservableObject {
     @Published var articles: [Article] = []
     @Published var isLoading: Bool = false


### PR DESCRIPTION
## Summary
- ensure property updates happen on the main actor by adding `@MainActor` annotation to `HeadlinesViewModel`

## Testing
- `swiftc ViewModels/HeadlinesViewModel.swift Networking/*.swift Models/*.swift -typecheck` *(fails: no such module 'SwiftUI')*
- `swiftc eTamil/*.swift eTamil/Models/*.swift eTamil/Networking/*.swift eTamil/ViewModels/*.swift eTamil/Views/*.swift -typecheck` *(fails: filename "Article.swift" used twice)*

------
https://chatgpt.com/codex/tasks/task_e_685e18ce2488832ebaf532cd0c557ab1